### PR TITLE
Replace #elseif by #elif in ccommon.h

### DIFF
--- a/include/b64/ccommon.h
+++ b/include/b64/ccommon.h
@@ -14,7 +14,7 @@ For details, see http://sourceforge.net/projects/libb64
 #ifndef HAVE_SIZE_T
   #ifdef _WIN32
     #include <crtdefs.h>
-  #elseif defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
+  #elif defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
     #include <stdlib.h>
   #else
     typedef unsigned long size_t;


### PR DESCRIPTION
#elseif is not a supported preprocessor definition. See [The Official C Standard](http://www.open-std.org/JTC1/SC22/WG14/www/docs/n1570.pdf) - See appendix "A.3  Preprocessing  directives".
Use #elif to prevent compiler errors.