### PR TITLE
Include <stddef.h> to import size_t definition

### DIFF
--- a/include/b64/ccommon.h
+++ b/include/b64/ccommon.h
@@ -11,14 +11,4 @@ For details, see http://sourceforge.net/projects/libb64
 #define BASE64_VER_MAJOR	2
 #define BASE64_VER_MINOR	0
 
-#ifndef HAVE_SIZE_T
-  #ifdef _WIN32
-    #include <crtdefs.h>
-  #elif defined (__unix__) || (defined (__APPLE__) && defined (__MACH__))
-    #include <stdlib.h>
-  #else
-    typedef unsigned long size_t;
-  #endif
-#endif
-
 #endif /* BASE64_CCOMMON_H */

--- a/include/b64/cdecode.h
+++ b/include/b64/cdecode.h
@@ -10,6 +10,8 @@ For details, see http://sourceforge.net/projects/libb64
 
 #include "ccommon.h"
 
+#include <stddef.h>
+
 #define BASE64_CDEC_VER_MAJOR   2
 #define BASE64_CDEC_VER_MINOR   0
 

--- a/include/b64/cencode.h
+++ b/include/b64/cencode.h
@@ -10,6 +10,8 @@ For details, see http://sourceforge.net/projects/libb64
 
 #include "ccommon.h"
 
+#include <stddef.h>
+
 #define BASE64_CENC_VER_MAJOR	2
 #define BASE64_CENC_VER_MINOR	0
 


### PR DESCRIPTION
This header is standard and is guaranteed to work even with C89/C90 which is supported by any C compiler out there I could think of.